### PR TITLE
Added default levels of theory

### DIFF
--- a/apioxy/__init__.py
+++ b/apioxy/__init__.py
@@ -1,3 +1,4 @@
 import apioxy.common
 import apioxy.main
 import apioxy.parsing
+from levels import LEVELS

--- a/apioxy/levels.py
+++ b/apioxy/levels.py
@@ -1,0 +1,40 @@
+"""
+APIOxy levels module
+used for storing default levels of theory
+"""
+
+from arc.level import Level
+
+
+# Not implementing the "ML" and "0" levels
+
+LEVELS = {1: {'sp_level': Level(method='wB97xd',
+                                basis='def2TZVP',
+                                solvation_method='COSMO/tzvpd-fine',  # Turbomol / Gaussian?
+                                solvent='water',  # mixture
+                                ),
+              'opt_level': Level(method='wB97xd',
+                                basis='def2SVP',
+                                ),
+              },
+          2: {'sp_level': Level(method='wB97MV',
+                                basis='def2TZVP',
+                                solvation_method='COSMO/tzvpd-fine',
+                                solvent='water',
+                                ),
+              'opt_level': Level(method='wB97xd',
+                                basis='def2SVP',
+                                ),
+              },
+          3: {'sp_level': Level(method='DLPNO',
+                                basis='def2TZVP',
+                                auxiliary_basis='def2TZVP/C',
+                                args={'keyword': {'dlpno_threshold': 'normalPNO'}},
+                                solvation_method='COSMO/tzvpd-fine',
+                                solvent='water',
+                                ),
+              'opt_level': Level(method='wB97xd',
+                                 basis='def2SVP',
+                                ),
+              },
+          }


### PR DESCRIPTION
Added default levels according to the following scheme:
```
ML: only ML, no RMG
0: ML, RMG, no QM
1: ML, RMG, GAV, QM = wB97xd/def2TZVP//wB97xd/def2SVP + COSMO/tzvpd-fine
2: ML, RMG, GAV, QM = wB97MV/def2TZVP//wB97xd/def2SVP + COSMO/tzvpd-fine
3: ML, RMG, GAV, QM = DLPNO/def2TZVP normalPNO aux=def2TZVP/C // wB97xd/def2SVP + COSMO/tzvpd-fine
custom: custom
```

Only 1, 2, 3 are implemented here